### PR TITLE
Jackd support for the GUI version

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -469,3 +469,17 @@
 	* Updated 'INSTALL'.
 2020-01-24 Fred Gleason <fredg@paravelsystems.com>
 	* Incremented the package version to 0.9.0.
+2021-08-06 Alejandro Olivan <alejandro.olivan.alvarez@gmail.com>
+  * Add capability to glassplayergui to use glassplayer's JACKD capabilities
+	  when passed the required parameters. Otherwise its functionality is kept
+		intact.
+	* Enable glassplayergui to catch and pass '--audio-device' switch to
+	  glassplayer.
+	* Enable glassplayergui to catch and pass '--jack-server-name' switch to
+	  glassplayer.
+	* Enable glassplayergui to catch and pass '--jack-client-name' switch to
+	  glassplayer.
+	* Modify glassplayergui window bar label to show the jackd client name when
+	  using JACKD audio device, to ease recognition of multiple instances.
+	* Modify the Metadata Title window bar label from a generic one, to one that
+	  best matches its coded functionality and comments.

--- a/ChangeLog
+++ b/ChangeLog
@@ -469,6 +469,23 @@
 	* Updated 'INSTALL'.
 2020-01-24 Fred Gleason <fredg@paravelsystems.com>
 	* Incremented the package version to 0.9.0.
+2021-05-03 Fred Gleason <fredg@paravelsystems.com>
+	* Added 'compile' to the 'make maintainer-clean' target.
+2021-05-03 Fred Gleason <fredg@paravelsystems.com>
+	* Cleaned up compiler warnings for glassplayer(1).
+	* Cleaned up compiler warnings for glassplayergui(1).
+2021-05-03 Fred Gleason <fredg@paravelsystems.com>
+	* Changed the format of the 'tone:' scheme to be compliant with the
+	host naming requirements in RFC1738.
+2021-05-03 Fred Gleason <fredg@paravelsystems.com>
+	* Debianized the source.
+2021-05-03 Fred Gleason <fredg@paravelsystems.com>
+	* Added a 'make deb' target.
+2021-05-04 Fred Gleason <fredg@paravelsystems.com>
+	* Updated the 'make deb' target.
+2021-05-21 Fred Gleason <fredg@paravelsystems.com>
+	* Split the 'glassplayer' DEB package into 'glassplayer' and
+	'glassplayer-gui' packages.
 2021-08-06 Alejandro Olivan <alejandro.olivan.alvarez@gmail.com>
 	* Add capability to glassplayergui to use glassplayer's JACKD capabilities
 	when passed the required parameters. Otherwise its functionality is kept

--- a/ChangeLog
+++ b/ChangeLog
@@ -470,16 +470,16 @@
 2020-01-24 Fred Gleason <fredg@paravelsystems.com>
 	* Incremented the package version to 0.9.0.
 2021-08-06 Alejandro Olivan <alejandro.olivan.alvarez@gmail.com>
-  * Add capability to glassplayergui to use glassplayer's JACKD capabilities
-	  when passed the required parameters. Otherwise its functionality is kept
-		intact.
+	* Add capability to glassplayergui to use glassplayer's JACKD capabilities
+	when passed the required parameters. Otherwise its functionality is kept
+	intact.
 	* Enable glassplayergui to catch and pass '--audio-device' switch to
-	  glassplayer.
+	glassplayer.
 	* Enable glassplayergui to catch and pass '--jack-server-name' switch to
-	  glassplayer.
+	glassplayer.
 	* Enable glassplayergui to catch and pass '--jack-client-name' switch to
-	  glassplayer.
+	glassplayer.
 	* Modify glassplayergui window bar label to show the jackd client name when
-	  using JACKD audio device, to ease recognition of multiple instances.
+	using JACKD audio device, to ease recognition of multiple instances.
 	* Modify the Metadata Title window bar label from a generic one, to one that
-	  best matches its coded functionality and comments.
+	best matches its coded functionality and comments.

--- a/compile
+++ b/compile
@@ -1,0 +1,1 @@
+/usr/share/automake-1.16/compile

--- a/compile
+++ b/compile
@@ -1,1 +1,0 @@
-/usr/share/automake-1.16/compile

--- a/docs/glassplayergui.xml
+++ b/docs/glassplayergui.xml
@@ -43,6 +43,77 @@
   </para>
   </refsect1>
 
+  <refsect1 id='options'><title>Options</title>
+    <variablelist remap='TP'>
+      <varlistentry>
+        <term>
+	        <option>--audio-device=</option><replaceable>type</replaceable>
+        </term>
+        <listitem>
+	        <para>
+	          Override the default audio type of audio device to use. The only recognized value is
+	          <userinput>JACK</userinput>. Any other audio type override or customization is not
+            supported.
+	          See the <emphasis remap='B'>DEVICE OPTIONS</emphasis> section (below) for
+	          the options appropriate for each audio device type.  Valid values
+	          are:
+	        </para>
+          <blockquote remap='RS'>
+        	  <variablelist remap='TP'>
+        	    <varlistentry>
+        	      <term>
+        		<userinput>JACK</userinput>
+        	      </term>
+        	      <listitem>
+        		<para>
+        		  The Jack Audio Connection Kit.
+        		</para>
+        	      </listitem>
+        	    </varlistentry>
+        	  </variablelist>
+        	</blockquote>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+  </refsect1>
+
+  <refsect1 id='device_options'><title>Device Options</title>
+  <variablelist remap='TP'>
+    <varlistentry>
+      <varlistentry>
+        <term>
+          <emphasis remap='B'>The Jack Audio Connection Kit</emphasis>
+          (<option>--audio-device=</option><userinput>JACK</userinput>)
+        </term>
+        <listitem>
+          <variablelist>
+    	<varlistentry>
+    	  <term>
+    	    <option>--jack-server-name=</option><replaceable>name</replaceable>
+    	  </term>
+    	  <listitem>
+    	    <para>
+    	      The name of the JACK server instance to use.
+    	    </para>
+    	  </listitem>
+    	</varlistentry>
+    	<varlistentry>
+    	  <term>
+    	    <option>--jack-client-name=</option><replaceable>name</replaceable>
+    	  </term>
+    	  <listitem>
+    	    <para>
+    	      The name of the JACK client to use.  Default is
+    	      <userinput>glassplayer</userinput>.
+    	    </para>
+    	  </listitem>
+    	</varlistentry>
+          </variablelist>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+  </refsect1>
+
   <refsect1 id='author'><title>Author</title>
   <para>
     Fred Gleason &lt;fredg@paravelsystems.com&gt;
@@ -57,4 +128,3 @@
   </para>
   </refsect1>
 </refentry>
-

--- a/docs/glassplayergui.xml
+++ b/docs/glassplayergui.xml
@@ -78,8 +78,7 @@
   </refsect1>
 
   <refsect1 id='device_options'><title>Device Options</title>
-  <variablelist remap='TP'>
-    <varlistentry>
+    <variablelist remap='TP'>
       <varlistentry>
         <term>
           <emphasis remap='B'>The Jack Audio Connection Kit</emphasis>
@@ -87,27 +86,27 @@
         </term>
         <listitem>
           <variablelist>
-    	<varlistentry>
-    	  <term>
-    	    <option>--jack-server-name=</option><replaceable>name</replaceable>
-    	  </term>
-    	  <listitem>
-    	    <para>
-    	      The name of the JACK server instance to use.
-    	    </para>
-    	  </listitem>
-    	</varlistentry>
-    	<varlistentry>
-    	  <term>
-    	    <option>--jack-client-name=</option><replaceable>name</replaceable>
-    	  </term>
-    	  <listitem>
-    	    <para>
-    	      The name of the JACK client to use.  Default is
-    	      <userinput>glassplayer</userinput>.
-    	    </para>
-    	  </listitem>
-    	</varlistentry>
+          	<varlistentry>
+          	  <term>
+          	    <option>--jack-server-name=</option><replaceable>name</replaceable>
+          	  </term>
+          	  <listitem>
+          	    <para>
+          	      The name of the JACK server instance to use.
+          	    </para>
+          	  </listitem>
+          	</varlistentry>
+          	<varlistentry>
+          	  <term>
+          	    <option>--jack-client-name=</option><replaceable>name</replaceable>
+          	  </term>
+          	  <listitem>
+          	    <para>
+          	      The name of the JACK client to use.  Default is
+          	      <userinput>glassplayer</userinput>.
+          	    </para>
+          	  </listitem>
+          	</varlistentry>
           </variablelist>
         </listitem>
       </varlistentry>

--- a/src/glassplayergui/glassplayergui.cpp
+++ b/src/glassplayergui/glassplayergui.cpp
@@ -160,7 +160,7 @@ void MainWidget::processStart(const QString &url, const QStringList &jackd_args)
   args.push_back("--metadata-out");
   args.push_back("--stats-out");
   if (!jackd_args.isEmpty()){
-    for ( const auto& jackdArg : jackd_args  )
+    for ( const auto& jackd_arg : jackd_args  )
     {
       args.push_back(jackdArg);
     }

--- a/src/glassplayergui/glassplayergui.cpp
+++ b/src/glassplayergui/glassplayergui.cpp
@@ -35,20 +35,20 @@ MainWidget::MainWidget(QWidget *parent)
 {
   gui_player_process=NULL;
   gui_logo_process=NULL;
-  jackdArgs=QStringList();
+  jackd_args=QStringList();
 
   CmdSwitch *cmd=new CmdSwitch("glassplayergui",GLASSPLAYERGUI_USAGE);
   if(cmd->keys()>0) {
     for(unsigned i=0;i<(cmd->keys()-1);i++) {
       if(cmd->key(i)=="--audio-device") {
-        jackdArgs.push_back("--audio-device=" + cmd->value(i));
+        jackd_args.push_back("--audio-device=" + cmd->value(i));
         cmd->setProcessed(i,false);
       } else if(cmd->key(i)=="--jack-server-name") {
-        jackdArgs.push_back("--jack-server-name=" + cmd->value(i));
+        jackd_args.push_back("--jack-server-name=" + cmd->value(i));
         cmd->setProcessed(i,false);
       } else if(cmd->key(i)=="--jack-client-name") {
-        jackdArgs.push_back("--jack-client-name=" + cmd->value(i));
-        jackdClientName = cmd->value(i);
+        jackd_args.push_back("--jack-client-name=" + cmd->value(i));
+        jackd_client_name = cmd->value(i);
         cmd->setProcessed(i,false);
       } else if (!cmd->processed(i)) {
 	      QMessageBox::critical(this,"GlassPlayer - "+tr("Error"),
@@ -66,10 +66,10 @@ MainWidget::MainWidget(QWidget *parent)
   QFont bold_font=font();
   bold_font.setWeight(QFont::Bold);
 
-  if (jackdClientName.isNull()) {
+  if (jackd_client_name.isNull()) {
     setWindowTitle(QString("GlassPlayer - v")+VERSION);
   } else {
-    setWindowTitle(jackdClientName+QString(" @ GlassPlayer - v")+VERSION);
+    setWindowTitle(jackd_client_name+QString(" @ GlassPlayer - v")+VERSION);
   }
 
   gui_stats_dialog=new StatsDialog(this);
@@ -125,7 +125,7 @@ MainWidget::MainWidget(QWidget *parent)
 	  this,SLOT(newJsonDocumentData(const QJsonDocument &)));
 
   if(!gui_url.isEmpty()) {
-    processStart(gui_url, jackdArgs);
+    processStart(gui_url, jackd_args);
   }
 
   setMinimumSize(sizeHint());
@@ -151,7 +151,7 @@ void MainWidget::showStatsData()
   }
 }
 
-void MainWidget::processStart(const QString &url, const QStringList &jackdArgs)
+void MainWidget::processStart(const QString &url, const QStringList &jackd_args)
 {
   QStringList args;
 
@@ -159,8 +159,8 @@ void MainWidget::processStart(const QString &url, const QStringList &jackdArgs)
   args.push_back("--meter-data");
   args.push_back("--metadata-out");
   args.push_back("--stats-out");
-  if (!jackdArgs.isEmpty()){
-    for ( const auto& jackdArg : jackdArgs  )
+  if (!jackd_args.isEmpty()){
+    for ( const auto& jackdArg : jackd_args  )
     {
       args.push_back(jackdArg);
     }

--- a/src/glassplayergui/glassplayergui.cpp
+++ b/src/glassplayergui/glassplayergui.cpp
@@ -162,7 +162,7 @@ void MainWidget::processStart(const QString &url, const QStringList &jackd_args)
   if (!jackd_args.isEmpty()){
     for ( const auto& jackd_arg : jackd_args  )
     {
-      args.push_back(jackdArg);
+      args.push_back(jackd_arg);
     }
   }
   args.push_back(url);

--- a/src/glassplayergui/glassplayergui.cpp
+++ b/src/glassplayergui/glassplayergui.cpp
@@ -35,14 +35,25 @@ MainWidget::MainWidget(QWidget *parent)
 {
   gui_player_process=NULL;
   gui_logo_process=NULL;
+  jackdArgs=QStringList();
 
   CmdSwitch *cmd=new CmdSwitch("glassplayergui",GLASSPLAYERGUI_USAGE);
   if(cmd->keys()>0) {
     for(unsigned i=0;i<(cmd->keys()-1);i++) {
-      if(!cmd->processed(i)) {
-	QMessageBox::critical(this,"GlassPlayer - "+tr("Error"),
-			      tr("Unknown argument")+" \""+cmd->key(i)+"\".");
-	exit(256);
+      if(cmd->key(i)=="--audio-device") {
+        jackdArgs.push_back("--audio-device=" + cmd->value(i));
+        cmd->setProcessed(i,false);
+      } else if(cmd->key(i)=="--jack-server-name") {
+        jackdArgs.push_back("--jack-server-name=" + cmd->value(i));
+        cmd->setProcessed(i,false);
+      } else if(cmd->key(i)=="--jack-client-name") {
+        jackdArgs.push_back("--jack-client-name=" + cmd->value(i));
+        jackdClientName = cmd->value(i);
+        cmd->setProcessed(i,false);
+      } else if (!cmd->processed(i)) {
+	      QMessageBox::critical(this,"GlassPlayer - "+tr("Error"),
+			    tr("Unknown argument")+" \""+cmd->key(i)+"\".");
+          exit(256);
       }
     }
     gui_url=cmd->key(cmd->keys()-1);
@@ -55,14 +66,18 @@ MainWidget::MainWidget(QWidget *parent)
   QFont bold_font=font();
   bold_font.setWeight(QFont::Bold);
 
-  setWindowTitle(QString("GlassPlayer - v")+VERSION);
+  if (jackdClientName.isNull()) {
+    setWindowTitle(QString("GlassPlayer - v")+VERSION);
+  } else {
+    setWindowTitle(jackdClientName+QString(" @ GlassPlayer - v")+VERSION);
+  }
 
   gui_stats_dialog=new StatsDialog(this);
 
   //
   // Metadata Title
   //
-  gui_title_text=new QLabel(tr("The GlassPlayer"),this);
+  gui_title_text=new QLabel(tr("Stream metadata"),this);
   gui_title_text->setFont(title_font);
 
   //
@@ -110,7 +125,7 @@ MainWidget::MainWidget(QWidget *parent)
 	  this,SLOT(newJsonDocumentData(const QJsonDocument &)));
 
   if(!gui_url.isEmpty()) {
-    processStart(gui_url);
+    processStart(gui_url, jackdArgs);
   }
 
   setMinimumSize(sizeHint());
@@ -136,8 +151,7 @@ void MainWidget::showStatsData()
   }
 }
 
-
-void MainWidget::processStart(const QString &url)
+void MainWidget::processStart(const QString &url, const QStringList &jackdArgs)
 {
   QStringList args;
 
@@ -145,6 +159,12 @@ void MainWidget::processStart(const QString &url)
   args.push_back("--meter-data");
   args.push_back("--metadata-out");
   args.push_back("--stats-out");
+  if (!jackdArgs.isEmpty()){
+    for ( const auto& jackdArg : jackdArgs  )
+    {
+      args.push_back(jackdArg);
+    }
+  }
   args.push_back(url);
   if(gui_player_process!=NULL) {
     delete gui_player_process;

--- a/src/glassplayergui/glassplayergui.h
+++ b/src/glassplayergui/glassplayergui.h
@@ -45,7 +45,7 @@ class MainWidget : public QMainWindow
 
  private slots:
   void showStatsData();
-  void processStart(const QString &url);
+  void processStart(const QString &url, const QStringList &jackdArgs);
   void processReadyReadData();
   void processFinishedData(int exit_code,QProcess::ExitStatus status);
   void processErrorData(QProcess::ProcessError err);
@@ -70,6 +70,8 @@ class MainWidget : public QMainWindow
   JsonParser *gui_json_parser;
   QStringList gui_stats_list;
   QString gui_url;
+  QStringList jackdArgs;
+  QString jackdClientName;  
   PlayMeter *gui_meters[MAX_AUDIO_CHANNELS];
   StatsDialog *gui_stats_dialog;
   QPushButton *gui_stats_button;

--- a/src/glassplayergui/glassplayergui.h
+++ b/src/glassplayergui/glassplayergui.h
@@ -45,7 +45,7 @@ class MainWidget : public QMainWindow
 
  private slots:
   void showStatsData();
-  void processStart(const QString &url, const QStringList &jackdArgs);
+  void processStart(const QString &url, const QStringList &jackd_args);
   void processReadyReadData();
   void processFinishedData(int exit_code,QProcess::ExitStatus status);
   void processErrorData(QProcess::ProcessError err);
@@ -70,8 +70,8 @@ class MainWidget : public QMainWindow
   JsonParser *gui_json_parser;
   QStringList gui_stats_list;
   QString gui_url;
-  QStringList jackdArgs;
-  QString jackdClientName;  
+  QStringList jackd_args;
+  QString jackd_client_name;
   PlayMeter *gui_meters[MAX_AUDIO_CHANNELS];
   StatsDialog *gui_stats_dialog;
   QPushButton *gui_stats_button;


### PR DESCRIPTION
Not sure if I'm doing this right... I'm not used to PR.

But the code changes have been tested for several months now... and I've had no issues at all. In reality there's nothing very interesting on the changes:

Basically, I've added the ability to (optionally) pass the glassplayer CLI params required to connect to jack, to the glassplayer-gui binary call, so it can in turn pass them when spawning the player.
When passing the jack client name, the resulting window title prepends the jack client name to the tittle, so it is easier to distinguish between multiple glassplayer-gui instances running as several, independent, jack clients.
I also changed the 'Metadata tittle' window title, according to the comment, because it was confusing to me... just cosmetic
Probably not the best coding practices, and I guess any changes should be documented on the man pages... but the functionality is very very useful to me. I missed very very much jackd on glassplayer-gui, while glassplayer, glasscoder and, overall, the rivendell ecosystem is fully jackd-friendly.

Best regards.